### PR TITLE
Fra default til pto namespace i prod

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -2,7 +2,7 @@ kind: Application
 apiVersion: nais.io/v1alpha1
 metadata:
   name: veilarblest
-  namespace: default
+  namespace: pto
   cluster: prod-fss
   labels:
     team: pto


### PR DESCRIPTION
Sikkerhetspolicy tillater kun AAD apper i team namespacer